### PR TITLE
option to enable/disable creating anchor on drag

### DIFF
--- a/src/anchorPointUtilities.js
+++ b/src/anchorPointUtilities.js
@@ -280,6 +280,55 @@ var anchorPointUtilities = {
     
     return anchorList;
   },
+  convertToAnchorAbsolutePositions: function (edge, type, anchorIndex) {
+    var srcPos = edge.source().position();
+    var tgtPos = edge.target().position();
+    var weights = edge.data(this.syntax[type]['weight']);
+    var distances = edge.data(this.syntax[type]['distance']);
+    var w = weights[ anchorIndex ];
+    var d = distances[ anchorIndex ];
+    var dy = ( tgtPos.y - srcPos.y );
+    var dx = ( tgtPos.x - srcPos.x );
+    var l = Math.sqrt( dx * dx + dy * dy );
+    var vector = {
+      x: dx,
+      y: dy
+    };
+    var vectorNorm = {
+      x: vector.x / l,
+      y: vector.y / l
+    };
+    var vectorNormInverse = {
+      x: -vectorNorm.y,
+      y: vectorNorm.x
+    };
+
+    var w1 = (1 - w);
+    var w2 = w;
+    var midX= srcPos.x * w1 + tgtPos.x * w2
+    var midY= srcPos.y * w1 + tgtPos.y * w2
+    var absoluteX= midX + vectorNormInverse.x * d
+    var absoluteY= midY + vectorNormInverse.y * d
+
+    return {x:absoluteX,y:absoluteY}
+  },
+  obtainPrevAnchorAbsolutePositions: function (edge, type, anchorIndex) {
+    if(anchorIndex<=0){
+      return edge.source().position();
+    }else{
+      return this.convertToAnchorAbsolutePositions(edge,type,anchorIndex-1)
+    }
+  },
+  obtainNextAnchorAbsolutePositions: function (edge, type, anchorIndex) {
+    var weights = edge.data(this.syntax[type]['weight']);
+    var distances = edge.data(this.syntax[type]['distance']);
+    var minLengths = Math.min( weights.length, distances.length );
+    if(anchorIndex>=minLengths-1){
+      return edge.target().position();
+    }else{
+      return this.convertToAnchorAbsolutePositions(edge,type,anchorIndex+1)
+    }
+  },
   convertToRelativePosition: function (edge, point, srcTgtPointsAndTangents) {
     if (srcTgtPointsAndTangents === undefined) {
       srcTgtPointsAndTangents = this.getSrcTgtPointsAndTangents(edge);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 ;(function(){ 'use strict';
   
-  var anchorPointUtilities = require('./anchorPointUtilities');
+  var anchorPointUtilities = require('./AnchorPointUtilities');
   var debounce = require("./debounce");
   
   // registers the extension on a cytoscape lib ref
@@ -10,21 +10,15 @@
     if( !cytoscape || !$ || !Konva){ return; } // can't register if required libraries unspecified
 
     var defaults = {
-      // A function parameter to get bend point positions, should return positions of bend points
+      // this function specifies the poitions of bend points
+      // strictly name the property 'bendPointPositions' for the edge to be detected for bend point edititng
       bendPositionsFunction: function(ele) {
         return ele.data('bendPointPositions');
       },
-      // A function parameter to get control point positions, should return positions of control points
+      // this function specifies the poitions of control points
+      // strictly name the property 'controlPointPositions' for the edge to be detected for control point edititng
       controlPositionsFunction: function(ele) {
         return ele.data('controlPointPositions');
-      },
-      // A function parameter to set bend point positions
-      bendPointPositionsSetterFunction: function(ele, bendPointPositions) {
-        ele.data('bendPointPositions', bendPointPositions);
-      },
-      // A function parameter to set bend point positions
-      controlPointPositionsSetterFunction: function(ele, controlPointPositions) {
-        ele.data('controlPointPositions', controlPointPositions);
       },
       // whether to initilize bend and control points on creation of this extension automatically
       initAnchorsAutomatically: true,
@@ -35,7 +29,9 @@
       // the size of bend and control point shape is obtained by multipling width of edge with this parameter
       anchorShapeSizeFactor: 3,
       // z-index value of the canvas in which bend and control points are drawn
-      zIndex: 999,
+      zIndex: 999,      
+      // whether to start the plugin in the enabled state
+      enabled: true,
       //An option that controls the distance within which a bend point is considered "near" the line segment between its two neighbors and will be automatically removed
       bendRemovalSensitivity : 8,
       // title of add bend point menu item (User may need to adjust width of menu items according to length of this option)
@@ -56,8 +52,8 @@
       },
       // whether 'Remove all bend points' and 'Remove all control points' options should be presented
       enableMultipleAnchorRemovalOption: false,
-      // specifically for edge-editing menu items, whether trailing dividers should be used
-      useTrailingDividersAfterContextMenuOptions: false,
+      // whether allows adding bending point by draging edge without useing ctxmenu, default is true
+      enableCreateAnchorOnDrag:true
     };
     
     var options;
@@ -130,12 +126,6 @@
           'edge-distances': 'node-position'
         });
 
-        cy.style().selector("#nwt_reconnectEdge_dummy").css({
-          'width' : '1',
-          'height' : '1',
-          'visibility' : 'hidden'
-        });
-
         anchorPointUtilities.setIgnoredClasses(options.ignoredClasses);
 
         // init bend positions conditionally
@@ -144,7 +134,10 @@
           anchorPointUtilities.initAnchorPoints(options.bendPositionsFunction, options.controlPositionsFunction, cy.edges(), options.ignoredClasses);
         }
 
-        uiUtilities(options, cy);
+        if(options.enabled)
+          uiUtilities(options, cy);
+        else
+          uiUtilities("unbind", cy);
       }
       
       var instance = initialized ? {
@@ -162,9 +155,6 @@
         },
         deleteSelectedAnchor: function(ele, index) {
           anchorPointUtilities.removeAnchor(ele, index);
-        },
-        getEdgeType: function(ele) {
-          return anchorPointUtilities.getEdgeType(ele);
         }
       } : undefined;
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,9 @@
       // whether 'Remove all bend points' and 'Remove all control points' options should be presented
       enableMultipleAnchorRemovalOption: false,
       // whether allows adding bending point by draging edge without useing ctxmenu, default is true
-      enableCreateAnchorOnDrag:true
+      enableCreateAnchorOnDrag:true,
+      // how to smartly move the anchor point to perfect 0 45 or 90 degree position, unit is px
+      stickyAnchorTolerence: -1  //-1 actually disable this feature, change it to 20 to test the feature
     };
     
     var options;


### PR DESCRIPTION
add an option enableCreateAnchorOnDrag into options. by default it is true so there is no change: user can drag the edge to create bend point. by setting it as false, user wont be able to do that.
